### PR TITLE
Add ARM64 system architecture support

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -20,6 +20,7 @@ install() {
   [ "Linux" = "$(uname)" ] && platform="linux" || platform="darwin"
   local arch
   [ "x86_64" = "$(uname -m)" ] && arch="amd64" || arch="386"
+  [ "aarch64" = "$(uname -m)" ] && arch="arm64"
 
   local download_url
   download_url="https://github.com/roboll/helmfile/releases/download/v${version}/helmfile_${platform}_${arch}"


### PR DESCRIPTION
The [releases page](https://github.com/roboll/helmfile/releases) on the helmfile project includes arm64 support, so I've added another conditional to set the variable `arch` to `arm64` when `uname -m` == `aarch64`

I use asdf on the raspberry pi and this package doesn't work with the 386/amd64 binaries. I have tested this change on a pi and the output is below:

```$ asdf plugin add helmfile https://github.com/mathew-fleisch/asdf-helmfile.git
$ asdf install helmfile latest
Downloading helmfile from https://github.com/roboll/helmfile/releases/download/v0.139.9/helmfile_linux_arm64
$ helmfile version
helmfile version v0.139.9