### PR TITLE
Support m1 macs

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -12,7 +12,6 @@ install() {
 
   local version=$2
   local install_path=$3
-
   local bin_install_path="$install_path/bin"
   local bin_path="${bin_install_path}/helmfile"
 
@@ -21,6 +20,7 @@ install() {
   local arch
   [ "x86_64" = "$(uname -m)" ] && arch="amd64" || arch="386"
   [ "aarch64" = "$(uname -m)" ] && arch="arm64"
+  [ "arm64" = "$(uname -m)" ] && arch="amd64" # m1 macs - no helmfile m1 builds as of yet, so use amd64
 
   local download_url
   download_url="https://github.com/roboll/helmfile/releases/download/v${version}/helmfile_${platform}_${arch}"


### PR DESCRIPTION
Helmfile doesn't yet provide m1 builds.  This allows the plugin to still work on m1 macs by using the amd64 build.

output of `uname -m` on an m1:
```
❯ uname -m
arm64
```