### PR TITLE
Show all release versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,17 +1,15 @@
 #!/usr/bin/env bash
 
-releases_path_old=https://api.github.com/repos/roboll/helmfile/releases
-releases_path_new=https://api.github.com/repos/helmfile/helmfile/releases
-cmd="curl -s"
-if [ -n "$GITHUB_API_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
-fi
-
-cmd="$cmd $releases_path_old && $cmd $releases_path_new"
-
 function sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
     LC_ALL=C sort -u -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-echo $(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//' | sort_versions)
+list_all_versions() {
+  git ls-remote --tags --refs https://github.com/helmfile/helmfile.git |
+    grep -o 'refs/tags/.*' |
+    cut -d/ -f3- |
+    sed 's/^v//'
+}
+
+list_all_versions | sort_versions | xargs echo


### PR DESCRIPTION
The github releases API is a paged API, so a request is only going to contain 25 releases at most. Maximum page size is 100.

Instead of using the GitHub API, fetch the versions from the git tags straight with git.

This approach was also used with the kubectl plugin already:
https://github.com/asdf-community/asdf-kubectl/pull/15/files